### PR TITLE
invalidate reference to free'd memory

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -344,6 +344,7 @@ fail:
 	if (uc)
 		av_freep(&uc->priv_data);
 	av_freep(&uc);
+	stream->h = NULL;
 #if HAVE_WINSOCK2_H
 	WSACleanup();
 #endif


### PR DESCRIPTION
When the caller fails to establish connection, it will attempt to use the reference established here to clean things up. This makes sense during a shutdown operation of a real stream, but libsrt_open won't even succeed in opening the connection. The logic down the line asserts the reference is valid with a null check, this is not actually ever set.